### PR TITLE
Replace npmjs.org by npmjs.com in tweet URL

### DIFF
--- a/lib/check-npm.js
+++ b/lib/check-npm.js
@@ -107,7 +107,7 @@ exports.CheckNPM.prototype.mungePackage = function(rawPackage) {
 		version: distTags.latest || false,
 		description: rawPackage.description || '',
 		name: rawPackage.name,
-		url: 'https://npmjs.org/package/' + escape(rawPackage.name)
+		url: 'https://npmjs.com/package/' + escape(rawPackage.name)
 	}
 };
 

--- a/test/test-check-npm.js
+++ b/test/test-check-npm.js
@@ -71,7 +71,7 @@ describe('CheckNPM', function() {
 			equal('foolib', mungedPackage.name);
 			equal('awesome', mungedPackage.description);
 			equal('0.0.1', mungedPackage.version);
-			equal('https://npmjs.org/package/foolib', mungedPackage.url);
+			equal('https://npmjs.com/package/foolib', mungedPackage.url);
 		});
 
 		it('should handle missing version and description keys', function() {
@@ -84,7 +84,7 @@ describe('CheckNPM', function() {
 			equal('foolib', mungedPackage.name);
 			equal('', mungedPackage.description);
 			equal(false, mungedPackage.version);
-			equal('https://npmjs.org/package/foolib', mungedPackage.url);
+			equal('https://npmjs.com/package/foolib', mungedPackage.url);
 		});
 
 		it('should handle missing author key', function() {


### PR DESCRIPTION
Hi.

I used to see nodenpm tweet, recently tweeted URL seems `Privacy error` in Chrome41. see also: https://npmjs.org/package/npm So I replaced npmjs.org by npmjs.com in tweet URL.

Thanks.